### PR TITLE
Table touch is not allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If the player in question doesn't have any lives left, this rule applies to the 
 - The blocked player has to shout "gandalf" and make an effort to still try to hit back the ball, preferrably hitting the blocker with the ping pong bat.
 
 ### Table Touch
-It's allowed to touch the table to support your body weight to smash the opponent by bending over the player's side of the table.
+It's **not** allowed to touch the table.
 
 ### Classics
 Classics are common patterns that return in Round The Table matches, noticably by the same players, which is the reason why the classics are named after them.


### PR DESCRIPTION
Just like the Olympic variant of round the table, we also should not tolerate table touching anymore! We've experimented with this rule for quite a while now and we've seen more diversity in the finals and a significant reduction of the time-to-final (the two OKRs) as notorious table touchers (@mvgijssel) can't use their dirty FULL table touch smash anymore.